### PR TITLE
Add algorithm selection option for percentile calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/yuya-takeyama/percentile
+
+go 1.24.7
+
+require (
+	github.com/jessevdk/go-flags v1.6.1
+	github.com/yuya-takeyama/argf v0.0.0-20150217044922-3ff699b4b958
+)
+
+require golang.org/x/sys v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
+github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
+github.com/yuya-takeyama/argf v0.0.0-20150217044922-3ff699b4b958 h1:Me/Pr07yvxPSqrFMOENfapb5rPBy9XMHqtk/cJXQucg=
+github.com/yuya-takeyama/argf v0.0.0-20150217044922-3ff699b4b958/go.mod h1:2ofZVA+WPX1lImOQjRpHBEn+vpk6FHYSwr3PyyiTCC4=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
Implemented two algorithms:
- simple: Original index-based calculation
- linear-interpolation: Improved calculation with linear interpolation for more accurate results

The linear-interpolation algorithm uses the formula: rank = p/100 * (n-1)

This provides more accurate percentile values, especially when the exact percentile falls between two data points.

Usage:
  percentile --algorithm=simple
  percentile --algorithm=linear-interpolation (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)